### PR TITLE
fix(types): generate typedef for Svelte component

### DIFF
--- a/src/Icons.test.svelte
+++ b/src/Icons.test.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Add16, BookmarkAdd16, BreakingChange16, Beta16 } from "../lib";
   import Icon from "../lib/Accessibility16";
+  import IconSvelte from "../lib/Accessibility16/Accessibility16.svelte";
 
   const icon = new Icon({ target: document.body, props: { focusable: true } });
 
@@ -22,3 +23,5 @@
 <BreakingChange16 />
 
 <svelte:component this={Beta16} />
+
+<IconSvelte title="" />

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,10 @@ export declare class CarbonIcon extends SvelteComponentTyped<
         `lib/${moduleName}/index.d.ts`,
         `export { ${moduleName} as default } from "../";\n`
       );
+      await writeFile(
+        `lib/${moduleName}/${moduleName}.svelte.d.ts`,
+        `export { ${moduleName} as default } from "../";\n`
+      );
     }
   });
 


### PR DESCRIPTION
Fixes #130 

Generate a typedef for the source Svelte component to support deep imports in TypeScript.