### PR TITLE
fix(typescript): correctly type `CarbonIcon` interface

### DIFF
--- a/src/Icons.test.svelte
+++ b/src/Icons.test.svelte
@@ -11,7 +11,7 @@
 
 <Add16
   title="Title"
-  fill="red"
+  style="fill: red"
   on:click={(e) => {
     console.log(e);
   }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,9 @@ const mkdir = promisify(fs.mkdir);
   await mkdir("lib");
 
   let libExport = "";
-  let definitions = `/// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-  
+  let definitions = `import { SvelteComponentTyped } from "svelte";
 
-
-export interface CarbonIconProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["svg"]> {
+export interface CarbonIconProps {
   /** @type {string} [id] */
   id?: string;
 
@@ -60,24 +57,6 @@ export interface CarbonIconProps extends svelte.JSX.HTMLAttributes<HTMLElementTa
 
   /** @type {string} [style] */
   style?: string;
-
-  /**
-   * Fill color
-   * @type {string} [fill="#161616"]
-   */
-  fill?: string;
-
-  /**
-   * Stroke color
-   * @type {string} [stroke="currentColor"]
-   */
-  stroke?: string;
-
-  /** @type {string} [width="48"] */
-  width?: string;
-
-  /** @type {string} [height="48"] */
-  height?: string;
 }
 
 export interface CarbonIconEvents {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,22 +40,40 @@ const mkdir = promisify(fs.mkdir);
   let definitions = `import { SvelteComponentTyped } from "svelte";
 
 export interface CarbonIconProps {
-  /** @type {string} [id] */
+  /**
+   * Specify an id.
+   * @default undefined
+   */
   id?: string;
 
-  /** @type {string} [class] */
+  /**
+   * Specify a class.
+   * @default undefined
+   */
   class?: string;
 
-  /** @type {string} [tabindex] */
+  /**
+   * Set to "0" for the icon to be focusable.
+   * @default undefined
+   */
   tabindex?: string;
 
-  /** @type {boolean} [focusable] */
+  /**
+   * Set to \`true\` for the icon to be focusable.
+   * @default false
+   */
   focusable?: boolean;
 
-  /** @type {string} [title] */
+  /**
+   * Set a title for the icon.
+   * @default undefined
+   */
   title?: string;
 
-  /** @type {string} [style] */
+  /**
+   * Set a style for the icon.
+   * @default undefined
+   */
   style?: string;
 }
 


### PR DESCRIPTION
The `CarbonIcon` interface should not extend svg props or include fill/stroke/width/height props.