### PR TITLE
fix: avoid duplicate exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,8 @@ export declare class CarbonIcon extends SvelteComponentTyped<
     },
   };
 
+  let names = new Set();
+
   iconModuleNames.forEach((moduleName) => {
     let name = moduleName;
 
@@ -84,6 +86,9 @@ export declare class CarbonIcon extends SvelteComponentTyped<
     } else {
       bySize.sizes.icon.push(name);
     }
+
+    if (names.has(name)) return;
+    names.add(name);
 
     byModuleName[name] = templateSvg(icon);
     libExport += `export { default as ${name} } from "./${name}.svelte";\n`;

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "vitest";
+import * as icons from "../lib";
+
+test("imports", () => {
+  expect(Object.keys(icons).length).toEqual(1922);
+});


### PR DESCRIPTION
Some icons were corrupted in version 11.0.0.

This is because icon names ending in Glyph are changed to remove "Glyph." As a result, this caused clashes with non-glyph icons with the same name. Because the icons are generated asynchronously, some files would be overwritten and thus corrupted (e.g., ChevronDown, Incomplete).

This also adds an import test to make sure `lib/index.js` is valid.