### PR TITLE
docs: avoid FOUC for theme

### DIFF
--- a/docs/src/components/index.svelte
+++ b/docs/src/components/index.svelte
@@ -1,7 +1,6 @@
 <script>
   /** @type {{ iconModuleNames?: string[]; byModuleName: Record<string, string>; bySize?: { order: string[]; sizes: Record<string, string>; }; total?: number; }} */
   import data from "../build-info.json";
-  import "carbon-components-svelte/css/all.css";
   import {
     Search,
     CodeSnippet,

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import "carbon-components-svelte/css/all.css";
 import Home from "../components/index.svelte";
 ---
 
@@ -13,8 +14,17 @@ import Home from "../components/index.svelte";
       content="Carbon Design System icons as Svelte components"
     />
     <title>Carbon Icons Svelte</title>
+    <script is:inline>
+      try {
+        const theme = localStorage.getItem("theme");
+
+        if (["white", "g10", "g80", "g90", "g100"].includes(theme)) {
+          document.documentElement.setAttribute("theme", theme);
+        }
+      } catch (e) {}
+    </script>
   </head>
   <body>
-    <Home client:load />
+    <Home client:idle />
   </body>
 </html>


### PR DESCRIPTION
There's a FOUC when visiting the page with a non-default theme.

This is because the Theme component is inside the `index.svelte` file; the JS has to be parsed before it's executed.

A much faster way is to inline a script that synchronously sets the persisted theme.