### PR TITLE
docs: fix link to CDS icon library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > [Carbon Design System](https://github.com/carbon-design-system) SVG icons as Svelte components.
 
-This zero dependency icon library builds [Carbon Design System icons](https://www.carbondesignsystem.com/guidelines/icons/library) as Svelte components. Although best paired with [carbon-components-svelte](https://github.com/IBM/carbon-components-svelte), these icons can be consumed standalone.
+This zero dependency icon library builds [Carbon Design System icons](https://www.carbondesignsystem.com/elements/icons/library) as Svelte components. Although best paired with [carbon-components-svelte](https://github.com/IBM/carbon-components-svelte), these icons can be consumed standalone.
 
 Try it in the [Svelte REPL](https://svelte.dev/repl/931e6a3461434622adad0557579c0a29).
 


### PR DESCRIPTION
Fixed the icon link for the carbon design system website in the readme