### PR TITLE
chore(deps-dev): upgrade typescript to 5.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
 
     "svelte": ["svelte@5.20.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "acorn-typescript": "^1.4.13", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^1.4.3", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-2Mo/AfObaw9zuD0u1JJ7sOVzRCGcpETEyDkLbtkcctWpCMCIyT0iz83xD8JT29SR7O4SgswuPRIDYReYF/607A=="],
 
-    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+    "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,5 @@
 declare module "@carbon/icons" {
-  import type IconDescriptor from "@carbon/icon-helpers/lib/types";
+  import type { toString } from "@carbon/icon-helpers";
 
   export type ModuleName = string;
 
@@ -15,7 +15,7 @@ declare module "@carbon/icons" {
         width: number;
         height: number;
       };
-      content: IconDescriptor[];
+      content: Parameters<typeof toString>[0][];
       name: string;
       size: number;
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import type { IconOutput, ModuleName } from "@carbon/icons";
-import metadata_11_31 from "@carbon/icons-11.31/metadata.json" assert { type: "json" };
-import metadata_latest from "@carbon/icons/metadata.json" assert { type: "json" };
+import metadata_11_31 from "@carbon/icons-11.31/metadata.json" with { type: "json" };
+import metadata_latest from "@carbon/icons/metadata.json" with { type: "json" };
 import { $ } from "bun";
-import { devDependencies, name } from "../package.json" assert { type: "json" };
-import { template, templateSvg } from "./template";
+import pkg from "../package.json" assert { type: "json" };
+import { template, templateSvg } from "./template.js";
 
-const VERSION = devDependencies["@carbon/icons"];
+const VERSION = pkg.devDependencies["@carbon/icons"];
 
 /**
  * This library is built using the `@carbon/icons` package.
@@ -124,11 +124,11 @@ export type CarbonIconProps = SvelteHTMLElements["svg"] & {
 
   const version = `[@carbon/icons@${VERSION}](https://unpkg.com/browse/@carbon/icons@${VERSION}/)`;
   const total = iconModuleNames.length;
-  const packageMetadata = `${total} icons from @carbon/icons@${devDependencies["@carbon/icons"]}`;
+  const packageMetadata = `${total} icons from @carbon/icons@${pkg.devDependencies["@carbon/icons"]}`;
 
   await Bun.write(
     "lib/index.d.ts",
-    `// Type definitions for ${name}
+    `// Type definitions for ${pkg.name}
 // ${packageMetadata}
 
 ${definitions}`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
+    "erasableSyntaxOnly": true,
     "esModuleInterop": true,
     "lib": ["esnext", "DOM"],
     "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "strict": true,
     "paths": {


### PR DESCRIPTION
Enable `erasableSyntaxOnly` and `module: "nodenex"`, and fix TS errors.